### PR TITLE
Avoid ignoring stdout when running exec

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -59,14 +59,13 @@ class Gry {
             args = null;
         }
 
-        eargs.push({ cwd: this.cwd });
+        eargs.push({ cwd: this.cwd, ignoreStdout:false });
 
         // Add the callback function
         eargs.push((err, stdout) => {
             if (err) { return callback(err); }
             callback(null, stdout.trimRight());
         });
-
         el.add("git", command, eargs[0], eargs[1]);
         return this;
     }


### PR DESCRIPTION
Stdout was not being sent to callback function when running exec, making commands that relay on stdout unnavailable, as an example this code would have no response:

```
const Gry = require("./lib/")
const path = './';
var repo = new Gry(path);

repo.exec(['shortlog', '-s', '-n', '--all', '--since', '1 January 2015', '--until', "now"], function (err, stdout) {
  if (err) {
    console.error(err); }
  else {
    console.log(stdout);
  }
})
```

Fixed by setting `ignoreStdout:false`